### PR TITLE
Fix megalinter sarif report upload and sha on github actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 Skatteverket - Swedish Tax Agency
-
-SPDX-License-Identifier: CC0-1.0
--->
-
 # Description
 
 Please include a summary of the change and which issue is fixed or added.

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,7 +12,7 @@ jobs:
 
     if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -11,7 +11,7 @@ jobs:
   reuse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 10
       - name: REUSE Compliance Check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,15 +6,24 @@
 name: MegaLinter
 on: [workflow_call] # yamllint disable-line rule:truthy
 
+permissions:
+  contents: read
+  security-events: write
+
 env:
   MEGALINTER_CONFIG: /github/workspace/build-tools/mega-linter.yml
+
 jobs:
   megalinter:
     name: megalint
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
         with:
           fetch-depth: 7
 
@@ -23,13 +32,13 @@ jobs:
         uses: oxsecurity/megalinter@v8.0.0
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 #v4.4.0
         with:
           name: MegaLinter reports
           path: |
             megalinter-reports
 
       - name: Upload Megalint Sarif Report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@4a01ec798636a8442fbe054c7795e139a5960d29 #v3.26.6
         with:
           sarif_file: megalinter-reports/megalinter-report.sarif

--- a/.github/workflows/lintpubliccode.yml
+++ b/.github/workflows/lintpubliccode.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: publiccode validation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - uses: italia/publiccode-parser-action@v1
         with:
           publiccode: "publiccode.yml"

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -31,8 +31,7 @@ jobs:
     steps:
       # Checkout project repository
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       # Install pnpm
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,12 +15,18 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   commit:
     uses: ./.github/workflows/commit.yml
   license:
     uses: ./.github/workflows/license.yml
   lint:
+    permissions:
+      contents: read
+      security-events: write  
     uses: ./.github/workflows/lint.yml
   lintpubliccode:
     uses: ./.github/workflows/lintpubliccode.yml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC0-1.0
 <a name="top"></a>
 <h1 align="center">
   <br>
-  <img src="https://github.com/diggsweden/mla/blob/main/assets/icon_banner.png" alt="MLA" width="200">
+  <img src="https://github.com/diggsweden/mla/blob/main/assets/icon.png" alt="MLA" width="200">
   <br>
   MLA
   <br>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -27,7 +27,7 @@ SPDX-License-Identifier = "CC0-1.0"
 
 # misc
 [[annotations]]
-path = ["CHANGELOG.md","**/*.json"]
+path = ["CHANGELOG.md","**/*.json",".github/pull_request_template.md"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 Skatteverket - Swedish Tax Agency"
 SPDX-License-Identifier = "CC0-1.0"


### PR DESCRIPTION
# Description

Change icon on README.md
Set SHA hash on GitHub Actions
Adjust permissions for sarif megalint upload

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).