### PR TITLE
fix: Use git commands instead of action to perform git merge fast for…

### DIFF
--- a/.github/workflows/fast_forward.yml
+++ b/.github/workflows/fast_forward.yml
@@ -9,22 +9,69 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   fast_forward_job:
     name: Fast Forward
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/fast-forward')   
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0
 
-      # Basic use case example
-      - name: Fast Forward PR
-        id: ff-action
-        uses: endre-spotlab/fast-forward-js-action@2.1
+      # Get details of the PR. The target and base branch. And also whether the PR can be merged in or not.
+      - name: Get PR details
+        uses: octokit/request-action@v2.3.1
+        id: get-pr-details
         with:
+          route: GET /repos/{repository}/pulls/{pull_number}
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          success_message: 'Success! Fast forwarded ***target_base*** to ***source_head***! ```git checkout target_base && git merge source_head --ff-only``` '
-          failure_message: 'Failed! Cannot do fast forward!'
-          production_branch: 'main'
+
+      # Merge (rebase) the PR if it is allowed.
+      - name: Fast forward the PR
+        id: merge-status
+        shell: bash
+        env:
+          HEAD_BRANCH: ${{ fromJson(steps.get-pr-details.outputs.data).head.ref }}
+          BASE_BRANCH: ${{ fromJson(steps.get-pr-details.outputs.data).base.ref }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"        
+          git checkout $HEAD_BRANCH
+          git checkout $BASE_BRANCH
+          git merge $HEAD_BRANCH --ff-only
+          git push
+          echo "::set-output name=message::'Fast forward successful.'"
+
+      # Post a success/failure comment to the PR.
+      - name: Add comment to PR
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: POST /repos/{repository}/issues/{issue_number}/comments
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          body: ${{ steps.merge-status.outputs.message }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Post a failure message when any of the previous steps fail.
+      - name: Add failure comment to PR
+        if: ${{ failure() }}
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: POST /repos/{repository}/issues/{issue_number}/comments
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          body: Unable to fast forward. Check the Actions execution tab for details.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Fix: Use git commands to do merge fast forward

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).