### PR TITLE
fix: Add renovate approve app as codewoner for files that uses automerge

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 # Current maintainers.
-*       @Racemovie  @Whiteflight
+*                   @Racemovie @Whiteflight
+package.json        app/renovate-approve
+pnpm-lock.yaml      app/renovate-approve


### PR DESCRIPTION
# Description

fix: Add renovate approve app as codewoner for files that uses automerge

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).